### PR TITLE
Add queryManager macro/decorator as Mixin alternative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add queryManager computed macro/decorator with support for classic Ember Object and Classes through decorators.
+
+### Deprecated
+
+- Mixins are deprecated in favor of queryManager computed macro.
+
 ## [v2.0.0-beta.4] - 2019-04-22
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add queryManager computed macro/decorator with support for classic Ember Object and Classes through decorators.
+- Add `queryManager` computed macro with support for classic Ember Object and ES6 classes through decorators (decorator syntax requires Ember v3.10.0).
 
 ### Deprecated
 
-- Mixins are deprecated in favor of queryManager computed macro.
+- Mixins are deprecated in favor of `queryManager` computed macro.
 
 ## [v2.0.0-beta.4] - 2019-04-22
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This addon works and is fully tested with:
 * Ember.js 3.4+
 * FastBoot 1.0+
 
-For compatibility with Ember versions below 3.4, use version 1.x. 
+For compatibility with Ember versions below 3.4, use version 1.x.
 
 ## Example App
 
@@ -249,7 +249,7 @@ While this library should work w/ any back-end implementation, here's an example
 `my-app/services/apollo.js`
 ```js
 import ApolloService from 'ember-apollo-client/services/apollo';
-import { inject as service } from '@ember-decorators/service';
+import { inject as service } from '@ember/service';
 import { Socket } from 'phoenix';
 import { createAbsintheSocketLink } from '@absinthe/socket-apollo-link';
 import AbsintheSocket from '@absinthe/socket';
@@ -274,7 +274,7 @@ Note: This will switch **all** gql communication to use websockets versus `http`
 `my-app/services/apollo.js`
 ```js
 import ApolloService from 'ember-apollo-client/services/apollo';
-import { inject as service } from '@ember-decorators/service';
+import { inject as service } from '@ember/service';
 import { Socket } from 'phoenix';
 import { split } from 'apollo-link';
 import { getMainDefinition } from 'apollo-utilities';
@@ -454,7 +454,7 @@ The `apollo` service has the following public API:
 
   ```js
   import ApolloService from 'ember-apollo-client/services/apollo';
-  import { inject as service } from '@ember-decorators/service';
+  import { inject as service } from '@ember/service';
   import { setContext } from 'apollo-link-context';
   import { Promise } from 'rsvp';
 
@@ -525,8 +525,7 @@ result of `query` via a method `_apolloUnsubscribe`.
 
 ### queryManager as decorator
 
-The `queryManager` computed macro can be used as a decorator. `ember-apollo-client` uses `ember-decorators` to implement the computed macro, and as per [Decorators RFC](https://github.com/emberjs/rfcs/pull/408) computed properties will work in both classic objects as well as classes by using decorators.
-
+The `queryManager` computed macro can be used as a decorator when using Ember v3.10.0 or above.
 
 ```js
 import Route from '@ember/routing/route';
@@ -545,11 +544,11 @@ export default class MyAwesomeRoute extends Route {
 
 ### queryManager options
 
-The `queryManager` computed macro can accept an options hash with the name of the service to use as apollo. 
+The `queryManager` computed macro can accept an options hash with the name of the service to use as apollo.
 If your application has a custom apollo service or multiple apollo services that extends from `ember-apollo-client/services/apollo`, you can use this option to specify which apollo service to use.
 
 ```js
-// imports ... 
+// imports ...
 
 export default class MyAwesomeRoute extends Route {
   @queryManager({ service: 'my-custom-apollo-service' }) apollo;

--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ result of `query` via a method `_apolloUnsubscribe`.
 
 ### queryManager as decorator
 
-The `queryManager` computed macro can be used as a decorator. `ember-apollo-client` uses `@ember-decorators/object` to implement the computed macro, and as per [Decorators RFC](https://github.com/emberjs/rfcs/pull/408) computed properties will work in both classic objects as well as classes by using decorators.
+The `queryManager` computed macro can be used as a decorator. `ember-apollo-client` uses `ember-decorators` to implement the computed macro, and as per [Decorators RFC](https://github.com/emberjs/rfcs/pull/408) computed properties will work in both classic objects as well as classes by using decorators.
 
 
 ```js

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ This addon works and is fully tested with:
 * Ember.js 3.4+
 * FastBoot 1.0+
 
+For compatibility with Ember versions below 3.4, use version 1.x. 
+
 ## Example App
 
 If you are looking for a full tutorial using `ember-apollo-client` check out the tutorial on [How To GraphQL](https://howtographql.com), written by [DevanB](https://github.com/DevanB).
@@ -136,20 +138,22 @@ const query = gql`
 `;
 ```
 
-Within your routes, you can query for data using the `RouteQueryManager`
-mixin and `watchQuery`:
+Within your routes, you can query for data using the `queryManager`
+computed macro and `watchQuery`:
 
 `app/routes/some-route.js`
 
 ```js
 import Route from "@ember/routing/route";
-import { RouteQueryManager } from "ember-apollo-client";
+import { queryManager } from "ember-apollo-client";
 import query from "my-app/gql/queries/human";
 
-export default Route.extend(RouteQueryManager, {
+export default Route.extend({
+  apollo: queryManager(),
+
   model(params) {
     let variables = { id: params.id };
-    return this.get('apollo').watchQuery({ query, variables }, "human");
+    return this.apollo.watchQuery({ query, variables }, "human");
   }
 });
 ```
@@ -165,10 +169,8 @@ the latest attributes (just like ember-data).
 Please note that when using `watchQuery`, you must
 [unsubscribe][unsubscribing] when you're done with the query data. You should
 only have to worry about this if you're using the [Apollo
-service][apollo-service-api] directly. If you use the `RouteQueryManager`
-mixin in your routes, or the `ComponentQueryManager` in your data-loading
-components, or the `ObjectQueryManager` in your data-loading on service or class that extend `Ember.Object`, all active watch queries are tracked and unsubscribed when the route is exited or the component and Ember.Object is destroyed. These mixins work by injecting a query manager named `apollo` that functions as a proxy to the `apollo`
-service.
+service][apollo-service-api] directly. If you use the `queryManager` computed macro in your routes, or in your data-loading
+components or class that extend `Ember.Object`, all active watch queries are tracked and unsubscribed when the route is exited or the component and Ember.Object is destroyed.
 
 You can instead use `query` if you just want a single query with a POJO
 response and no watch updates.
@@ -221,10 +223,12 @@ subscription {
 
 ```js
 import Route from '@ember/routing/route';
-import { RouteQueryManager } from 'ember-apollo-client';
+import { queryManager } from 'ember-apollo-client';
 import query from 'app/gql/subscriptions/new-human';
 
-export default Route.extend(RouteQueryManager, {
+export default Route.extend({
+  apollo: queryManager(),
+
   model() {
     return this.get('apollo')
                .subscribe({ query }, 'human');
@@ -236,7 +240,7 @@ export default Route.extend(RouteQueryManager, {
 });
 ```
 
-The big advantage of using the `RouteQueryManager` is that when you navigate away from this route, all subscriptions created will be terminated. That said, if you want to manually unsubscribe (or are not using the `RouteQueryManager`) `subscription.unsubscribe()` will do the trick.
+The big advantage of using the `queryManager` is that when you navigate away from this route, all subscriptions created will be terminated. That said, if you want to manually unsubscribe (or are not using the `queryManager`) `subscription.unsubscribe()` will do the trick.
 
 **Enabling Websockets**
 
@@ -393,7 +397,7 @@ export default Route.extend({
 ### Apollo service API
 
 You should not need to use the Apollo service directly for most regular
-usage, instead utilizing the `RouteQueryManager`, `ObjectQueryManager` and `ComponentQueryManager` mixins. However, you will probably need to customize options on the `apollo` service, and might need to query it directly for some use cases (such as
+usage, instead utilizing the `queryManager` computed macro. However, you will probably need to customize options on the `apollo` service, and might need to query it directly for some use cases (such as
 loading data from a service rather than a route or component).
 
 The `apollo` service has the following public API:
@@ -512,39 +516,46 @@ whenever the store is updated with new data about the resolved objects. This
 happens until you explicitly unsubscribe from it.
 
 In ember-apollo-client, most unsubscriptions are handled automatically by the
-`RouteQueryManager`, `ObjectQueryManager` and `ComponentQueryManager` mixins,
-so long as you use them.
+`queryManager` computed macro, so long as you use it.
 
 If you're fetching data elsewhere, such as in an Ember Service, or if you use
 the Apollo service directly, you are responsible for unsubscribing from
 `watchQuery` results when you're done with them. This is exposed on the
 result of `query` via a method `_apolloUnsubscribe`.
 
-### Injecting the `RouteQueryManager` mixin into all routes
+### queryManager as decorator
 
-ember-apollo-client does not automatically inject any dependencies into your
-routes. If you want to inject this mixin into all routes, you should utilize
-a base route class:
+The `queryManager` computed macro can be used as a decorator. `ember-apollo-client` uses `@ember-decorators/object` to implement the computed macro, and as per [Decorators RFC](https://github.com/emberjs/rfcs/pull/408) computed properties will work in both classic objects as well as classes by using decorators.
 
-`app/routes/base.js`
 
 ```js
-import Route from "@ember/routing/route";
-import { RouteQueryManager } from "ember-apollo-client";
+import Route from '@ember/routing/route';
+import { queryManager } from 'ember-apollo-client'
+import query from 'my-app/gql/queries/human';
 
-export default Route.extend(RouteQueryManager);
+export default class MyAwesomeRoute extends Route {
+  @queryManager apollo;
+
+  model({ id }) {
+    let variables = { id };
+    return this.apollo.watchQuery({ query, variables });
+  }
+}
 ```
 
-Then extend from that in your other routes:
+### queryManager options
 
-`app/routes/a-real-route.js`
+The `queryManager` computed macro can accept an options hash with the name of the service to use as apollo. 
+If your application has a custom apollo service or multiple apollo services that extends from `ember-apollo-client/services/apollo`, you can use this option to specify which apollo service to use.
 
 ```js
-import Base from "my-app/routes/base";
+// imports ... 
 
-export default Base.extend(
-  ...
-)
+export default class MyAwesomeRoute extends Route {
+  @queryManager({ service: 'my-custom-apollo-service' }) apollo;
+
+  // ...
+}
 ```
 
 ### Use with Fastboot

--- a/addon/-private/apollo/query-manager.js
+++ b/addon/-private/apollo/query-manager.js
@@ -1,3 +1,29 @@
+import { getOwner } from '@ember/application';
+import { computed } from '@ember-decorators/object';
+import setupHooks from './setup-hooks';
+
+export function queryManager(options = {}) {
+  let serviceName = 'apollo';
+  if (typeof options === 'object' && options.service) {
+    serviceName = options.service;
+  }
+
+  const macro = computed({
+    get() {
+      const service = getOwner(this).lookup(`service:${serviceName}`);
+      const queryManager = new QueryManager(service);
+      setupHooks(queryManager, this);
+      return queryManager;
+    },
+  });
+
+  if (arguments.length > 1) {
+    return macro(...arguments);
+  }
+
+  return macro;
+}
+
 export default class QueryManager {
   apollo = undefined;
   activeSubscriptions = [];

--- a/addon/-private/apollo/query-manager.js
+++ b/addon/-private/apollo/query-manager.js
@@ -1,28 +1,28 @@
 import { getOwner } from '@ember/application';
-import { computed } from '@ember-decorators/object';
+import { computed } from '@ember/object';
 import setupHooks from './setup-hooks';
+import { computedDecoratorWithParams } from '@ember-decorators/utils/computed';
 
-export function queryManager(options = {}) {
+function macro(options = {}) {
   let serviceName = 'apollo';
   if (typeof options === 'object' && options.service) {
     serviceName = options.service;
   }
 
-  const macro = computed({
-    get() {
-      const service = getOwner(this).lookup(`service:${serviceName}`);
-      const queryManager = new QueryManager(service);
-      setupHooks(queryManager, this);
-      return queryManager;
-    },
+  return computed(function() {
+    const service = getOwner(this).lookup(`service:${serviceName}`);
+    const queryManager = new QueryManager(service);
+    setupHooks(queryManager, this);
+    return queryManager;
   });
-
-  if (arguments.length > 1) {
-    return macro(...arguments);
-  }
-
-  return macro;
 }
+
+export const queryManager = computedDecoratorWithParams(function(_, params) {
+  if (typeof params === 'undefined') {
+    return macro();
+  }
+  return macro(...params);
+});
 
 export default class QueryManager {
   apollo = undefined;

--- a/addon/-private/apollo/setup-hooks.js
+++ b/addon/-private/apollo/setup-hooks.js
@@ -1,0 +1,46 @@
+import Component from '@ember/component';
+import Route from '@ember/routing/route';
+
+const hooks = {
+  willDestroyElement() {
+    this.unsubscribeAll(false);
+  },
+
+  beforeModel() {
+    this.markSubscriptionsStale();
+  },
+
+  resetController(_, isExiting) {
+    this.unsubscribeAll(!isExiting);
+  },
+
+  willDestroy() {
+    if (this.unsubscribeAll) {
+      this.unsubscribeAll(false);
+    }
+  },
+};
+
+function installHook(queryManager, context, hookName) {
+  let hook = hooks[hookName].bind(queryManager);
+  let originalHook = context[hookName];
+
+  context[hookName] = function() {
+    if (typeof originalHook === 'function') {
+      originalHook.call(this, ...arguments);
+    }
+    hook.call(queryManager, ...arguments);
+  };
+}
+
+export default function setupHooks(queryManager, context) {
+  if (context instanceof Component) {
+    installHook(queryManager, context, 'willDestroyElement');
+  } else if (context instanceof Route) {
+    installHook(queryManager, context, 'beforeModel');
+    installHook(queryManager, context, 'resetController');
+    installHook(queryManager, context, 'willDestroy');
+  } else {
+    installHook(queryManager, context, 'willDestroy');
+  }
+}

--- a/addon/-private/mixins/base-query-manager.js
+++ b/addon/-private/mixins/base-query-manager.js
@@ -1,10 +1,32 @@
 import { inject as service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
 import { computed } from '@ember/object';
+import { deprecate } from '@ember/application/deprecations';
 
 export default Mixin.create({
   apolloService: service('apollo'),
   apollo: computed('apolloService', function() {
     return this.get('apolloService').createQueryManager();
   }),
+  init() {
+    this._super(...arguments);
+
+    deprecate(
+      `
+Mixins in ember-apollo-client are deprecated, use queryManager macro instead.
+
+import { queryManager } from 'ember-apollo-client';
+
+export default Route.extend({
+  apollo: queryManager(),
+
+  // ...
+});`,
+      false,
+      {
+        id: 'ember-apollo-client.deprecate-mixins',
+        until: '3.0.0',
+      }
+    );
+  },
 });

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,6 +1,7 @@
-import ComponentQueryManager from 'ember-apollo-client/-private/mixins/component-query-manager';
-import ObjectQueryManager from 'ember-apollo-client/-private/mixins/object-query-manager';
-import RouteQueryManager from 'ember-apollo-client/-private/mixins/route-query-manager';
+import ComponentQueryManager from './-private/mixins/component-query-manager';
+import ObjectQueryManager from './-private/mixins/object-query-manager';
+import RouteQueryManager from './-private/mixins/route-query-manager';
+import QueryManager, { queryManager } from './-private/apollo/query-manager';
 
 export function getObservable(queryResult) {
   return queryResult._apolloObservable;
@@ -8,4 +9,10 @@ export function getObservable(queryResult) {
 
 export let apolloObservableKey = '_apolloObservable';
 
-export { ComponentQueryManager, ObjectQueryManager, RouteQueryManager };
+export {
+  queryManager,
+  QueryManager,
+  ComponentQueryManager,
+  ObjectQueryManager,
+  RouteQueryManager,
+};

--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -1,23 +1,22 @@
 import Ember from 'ember';
 import EmberObject, { get, setProperties } from '@ember/object';
 import Evented from '@ember/object/evented';
+import RSVP from 'rsvp';
 import Service from '@ember/service';
+import copyWithExtras from '../utils/copy-with-extras';
+import fetch from 'fetch';
 import { A } from '@ember/array';
+import { ApolloClient } from 'apollo-client';
+import { InMemoryCache } from 'apollo-cache-inmemory';
+import { assign } from '@ember/polyfills';
+import { createHttpLink } from 'apollo-link-http';
+import { getOwner } from '@ember/application';
 import { isArray } from '@ember/array';
 import { isNone, isPresent } from '@ember/utils';
-import { getOwner } from '@ember/application';
-import { assign } from '@ember/polyfills';
-import RSVP from 'rsvp';
-import { run } from '@ember/runloop';
-import { ApolloClient } from 'apollo-client';
-import { createHttpLink } from 'apollo-link-http';
-import { InMemoryCache } from 'apollo-cache-inmemory';
-import { apolloObservableKey } from 'ember-apollo-client';
-import QueryManager from 'ember-apollo-client/apollo/query-manager';
-import copyWithExtras from 'ember-apollo-client/utils/copy-with-extras';
 import { registerWaiter } from '@ember/test';
-import fetch from 'fetch';
 import deprecateComputed from 'ember-apollo-client/-private/deprecate-computed';
+import { run } from '@ember/runloop';
+import { apolloObservableKey, QueryManager } from '../index';
 
 class EmberApolloSubscription extends EmberObject.extend(Evented) {
   lastEvent = null;

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,12 +3,7 @@
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  let app = new EmberAddon(defaults, {
-    'ember-cli-babel': {
-      // Necessary for Object.assign when testing in the dummy app with PhantomJS
-      includePolyfill: true,
-    },
-  });
+  let app = new EmberAddon(defaults, {});
 
   /*
     This build file specifies the options for the dummy test app of this

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ember-cli-pretender": "^3.1.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",
+    "ember-compatibility-helpers": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",
     "ember-fetch": "^6.7.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",
-    "@ember-decorators/object": "^5.1.4",
+    "@ember-decorators/object": "^6.0.0",
     "@ember/optional-features": "^0.7.0",
     "@playlyfe/gql": "^2.6.1",
     "babel-eslint": "^10.0.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",
+    "@ember-decorators/object": "^5.1.4",
     "@ember/optional-features": "^0.7.0",
     "@playlyfe/gql": "^2.6.1",
     "babel-eslint": "^10.0.2",

--- a/tests/dummy/app/routes/anakin.js
+++ b/tests/dummy/app/routes/anakin.js
@@ -1,11 +1,13 @@
 import Route from '@ember/routing/route';
-import { RouteQueryManager } from 'ember-apollo-client';
 import query from 'dummy/gql/queries/human';
 import mutation from 'dummy/gql/mutations/change-character-name';
+import { queryManager } from 'ember-apollo-client';
 
 const variables = { id: '1000' };
 
-export default Route.extend(RouteQueryManager, {
+export default Route.extend({
+  apollo: queryManager(),
+
   model() {
     return this.get('apollo').watchQuery(
       {

--- a/tests/dummy/app/routes/characters.js
+++ b/tests/dummy/app/routes/characters.js
@@ -1,8 +1,10 @@
 import Route from '@ember/routing/route';
-import { RouteQueryManager } from 'ember-apollo-client';
 import query from 'dummy/gql/queries/characters';
+import { queryManager } from 'ember-apollo-client';
 
-export default Route.extend(RouteQueryManager, {
+export default Route.extend({
+  apollo: queryManager(),
+
   queryParams: {
     kind: {
       refreshModel: true,

--- a/tests/dummy/app/routes/luke.js
+++ b/tests/dummy/app/routes/luke.js
@@ -1,10 +1,12 @@
 import Route from '@ember/routing/route';
-import { RouteQueryManager } from 'ember-apollo-client';
+import { queryManager } from 'ember-apollo-client';
 import query from 'dummy/gql/queries/human';
 
 const variables = { id: '1000' };
 
-export default Route.extend(RouteQueryManager, {
+export default Route.extend({
+  apollo: queryManager(),
+
   model() {
     return this.get('apollo').watchQuery(
       {

--- a/tests/dummy/app/routes/new-review.js
+++ b/tests/dummy/app/routes/new-review.js
@@ -1,8 +1,11 @@
 import Route from '@ember/routing/route';
 import EmberObject from '@ember/object';
 import mutation from 'dummy/gql/mutations/create-review';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
+  apollo: service(),
+
   model() {
     return EmberObject.create({});
   },

--- a/tests/unit/-private/query-manager-hooks-component-test.js
+++ b/tests/unit/-private/query-manager-hooks-component-test.js
@@ -3,6 +3,7 @@ import { queryManager } from 'ember-apollo-client';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import ApolloService from 'ember-apollo-client/services/apollo';
+import { gte } from 'ember-compatibility-helpers';
 
 let TestObject;
 let unsubscribeCalled;
@@ -91,28 +92,30 @@ module('Unit | queryManager | Setup Hooks in Ember Components', function(
     );
   });
 
-  test('it works using decorator syntax', function(assert) {
-    assert.expect(5);
-    TestObject = class MyTestClassOjbect extends EmberComponent {
-      @queryManager({ service: 'overridden-apollo' }) apollo;
+  if (gte('3.10.0')) {
+    test('it works using decorator syntax', function(assert) {
+      assert.expect(5);
+      TestObject = class MyTestClassOjbect extends EmberComponent {
+        @queryManager({ service: 'overridden-apollo' }) apollo;
 
-      willDestroyElement() {
-        assert.ok(true, 'Should have called the original willDestroyElement');
-      }
-    };
+        willDestroyElement() {
+          assert.ok(true, 'Should have called the original willDestroyElement');
+        }
+      };
 
-    let subject = this.subject();
-    assert.equal(unsubscribeCalled, 0, 'should have been initialized with 0');
+      let subject = this.subject();
+      assert.equal(unsubscribeCalled, 0, 'should have been initialized with 0');
 
-    subject.apollo.watchQuery({ query: 'fakeQuery' });
-    subject.apollo.watchQuery({ query: 'fakeQuery' });
+      subject.apollo.watchQuery({ query: 'fakeQuery' });
+      subject.apollo.watchQuery({ query: 'fakeQuery' });
 
-    subject.willDestroyElement();
+      subject.willDestroyElement();
 
-    assert.equal(
-      unsubscribeCalled,
-      2,
-      '_apolloUnsubscribe() was called once per watchQuery'
-    );
-  });
+      assert.equal(
+        unsubscribeCalled,
+        2,
+        '_apolloUnsubscribe() was called once per watchQuery'
+      );
+    });
+  }
 });

--- a/tests/unit/-private/query-manager-hooks-component-test.js
+++ b/tests/unit/-private/query-manager-hooks-component-test.js
@@ -1,0 +1,118 @@
+import EmberComponent from '@ember/component';
+import { queryManager } from 'ember-apollo-client';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import ApolloService from 'ember-apollo-client/services/apollo';
+
+let TestObject;
+let unsubscribeCalled;
+let assertDeepEqual;
+
+let OverriddenApollo = class extends ApolloService {
+  managedWatchQuery(manager, opts) {
+    assertDeepEqual(opts, { query: 'fakeQuery' });
+
+    manager.trackSubscription({
+      unsubscribe() {
+        unsubscribeCalled++;
+      },
+    });
+  }
+
+  managedSubscribe(manager, opts) {
+    assertDeepEqual(opts, { query: 'fakeSubscription' });
+
+    manager.trackSubscription({
+      unsubscribe() {
+        unsubscribeCalled++;
+      },
+    });
+  }
+};
+
+module('Unit | queryManager | Setup Hooks in Ember Components', function(
+  hooks
+) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function(assert) {
+    assertDeepEqual = assert.deepEqual.bind(assert);
+    unsubscribeCalled = 0;
+
+    this.subject = function() {
+      this.owner.register('service:overridden-apollo', OverriddenApollo);
+      this.owner.register('component:test-component', TestObject);
+      return this.owner.lookup('component:test-component');
+    };
+  });
+
+  test('it unsubscribes from any watchQuery subscriptions', function(assert) {
+    assert.expect(5);
+
+    TestObject = EmberComponent.extend({
+      apollo: queryManager({ service: 'overridden-apollo' }),
+      willDestroyElement() {
+        assert.ok(true, 'Should have called the original willDestroyElement');
+      },
+    });
+
+    let subject = this.subject();
+    assert.equal(unsubscribeCalled, 0, 'should have been initialized with 0');
+
+    subject.apollo.watchQuery({ query: 'fakeQuery' });
+    subject.apollo.watchQuery({ query: 'fakeQuery' });
+
+    subject.willDestroyElement();
+
+    assert.equal(
+      unsubscribeCalled,
+      2,
+      '_apolloUnsubscribe() was called once per watchQuery'
+    );
+  });
+
+  test('it unsubscribes from any subscriptions', async function(assert) {
+    TestObject = EmberComponent.extend({
+      apollo: queryManager({ service: 'overridden-apollo' }),
+    });
+
+    let subject = this.subject();
+    assert.equal(unsubscribeCalled, 0, 'should have been initialized with 0');
+
+    subject.apollo.subscribe({ query: 'fakeSubscription' });
+    subject.apollo.subscribe({ query: 'fakeSubscription' });
+
+    subject.willDestroyElement();
+
+    assert.equal(
+      unsubscribeCalled,
+      2,
+      '_apolloUnsubscribe() was called once per subscribe'
+    );
+  });
+
+  test('it works using decorator syntax', function(assert) {
+    assert.expect(5);
+    TestObject = class MyTestClassOjbect extends EmberComponent {
+      @queryManager({ service: 'overridden-apollo' }) apollo;
+
+      willDestroyElement() {
+        assert.ok(true, 'Should have called the original willDestroyElement');
+      }
+    };
+
+    let subject = this.subject();
+    assert.equal(unsubscribeCalled, 0, 'should have been initialized with 0');
+
+    subject.apollo.watchQuery({ query: 'fakeQuery' });
+    subject.apollo.watchQuery({ query: 'fakeQuery' });
+
+    subject.willDestroyElement();
+
+    assert.equal(
+      unsubscribeCalled,
+      2,
+      '_apolloUnsubscribe() was called once per watchQuery'
+    );
+  });
+});

--- a/tests/unit/-private/query-manager-hooks-object-test.js
+++ b/tests/unit/-private/query-manager-hooks-object-test.js
@@ -3,6 +3,7 @@ import { queryManager } from 'ember-apollo-client';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import ApolloService from 'ember-apollo-client/services/apollo';
+import { gte } from 'ember-compatibility-helpers';
 
 let TestObject;
 let unsubscribeCalled;
@@ -89,28 +90,30 @@ module('Unit | queryManager | Setup Hooks in EmberOject', function(hooks) {
     );
   });
 
-  test('it works using decorator syntax', function(assert) {
-    assert.expect(6);
-    TestObject = class MyTestClassOjbect extends EmberObject {
-      @queryManager({ service: 'overridden-apollo' }) apollo;
+  if (gte('3.10.0')) {
+    test('it works using decorator syntax', function(assert) {
+      assert.expect(6);
+      TestObject = class MyTestClassOjbect extends EmberObject {
+        @queryManager({ service: 'overridden-apollo' }) apollo;
 
-      willDestroy() {
-        assert.ok(true, 'Should have called the original willDestroy');
-      }
-    };
+        willDestroy() {
+          assert.ok(true, 'Should have called the original willDestroy');
+        }
+      };
 
-    let subject = this.subject();
-    assert.equal(unsubscribeCalled, 0, 'should have been initialized with 0');
+      let subject = this.subject();
+      assert.equal(unsubscribeCalled, 0, 'should have been initialized with 0');
 
-    subject.apollo.watchQuery({ query: 'fakeQuery' });
-    subject.apollo.watchQuery({ query: 'fakeQuery' });
+      subject.apollo.watchQuery({ query: 'fakeQuery' });
+      subject.apollo.watchQuery({ query: 'fakeQuery' });
 
-    subject.willDestroy();
+      subject.willDestroy();
 
-    assert.equal(
-      unsubscribeCalled,
-      2,
-      '_apolloUnsubscribe() was called once per watchQuery'
-    );
-  });
+      assert.equal(
+        unsubscribeCalled,
+        2,
+        '_apolloUnsubscribe() was called once per watchQuery'
+      );
+    });
+  }
 });

--- a/tests/unit/-private/query-manager-hooks-object-test.js
+++ b/tests/unit/-private/query-manager-hooks-object-test.js
@@ -1,0 +1,116 @@
+import EmberObject from '@ember/object';
+import { queryManager } from 'ember-apollo-client';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import ApolloService from 'ember-apollo-client/services/apollo';
+
+let TestObject;
+let unsubscribeCalled;
+let assertDeepEqual;
+
+let OverriddenApollo = class extends ApolloService {
+  managedWatchQuery(manager, opts) {
+    assertDeepEqual(opts, { query: 'fakeQuery' });
+
+    manager.trackSubscription({
+      unsubscribe() {
+        unsubscribeCalled++;
+      },
+    });
+  }
+
+  managedSubscribe(manager, opts) {
+    assertDeepEqual(opts, { query: 'fakeSubscription' });
+
+    manager.trackSubscription({
+      unsubscribe() {
+        unsubscribeCalled++;
+      },
+    });
+  }
+};
+
+module('Unit | queryManager | Setup Hooks in EmberOject', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function(assert) {
+    assertDeepEqual = assert.deepEqual.bind(assert);
+    unsubscribeCalled = 0;
+
+    this.subject = function() {
+      this.owner.register('service:overridden-apollo', OverriddenApollo);
+      this.owner.register('test-container:test-object', TestObject);
+      return this.owner.lookup('test-container:test-object');
+    };
+  });
+
+  test('it unsubscribes from any watchQuery subscriptions', function(assert) {
+    assert.expect(6);
+
+    TestObject = EmberObject.extend({
+      apollo: queryManager({ service: 'overridden-apollo' }),
+      willDestroy() {
+        assert.ok(true, 'Should have called the original willDestroy');
+      },
+    });
+
+    let subject = this.subject();
+    assert.equal(unsubscribeCalled, 0, 'should have been initialized with 0');
+
+    subject.apollo.watchQuery({ query: 'fakeQuery' });
+    subject.apollo.watchQuery({ query: 'fakeQuery' });
+
+    subject.willDestroy();
+
+    assert.equal(
+      unsubscribeCalled,
+      2,
+      '_apolloUnsubscribe() was called once per watchQuery'
+    );
+  });
+
+  test('it unsubscribes from any subscriptions', async function(assert) {
+    TestObject = EmberObject.extend({
+      apollo: queryManager({ service: 'overridden-apollo' }),
+    });
+
+    let subject = this.subject();
+    assert.equal(unsubscribeCalled, 0, 'should have been initialized with 0');
+
+    subject.apollo.subscribe({ query: 'fakeSubscription' });
+    subject.apollo.subscribe({ query: 'fakeSubscription' });
+
+    subject.willDestroy();
+
+    assert.equal(
+      unsubscribeCalled,
+      2,
+      '_apolloUnsubscribe() was called once per subscribe'
+    );
+  });
+
+  test('it works using decorator syntax', function(assert) {
+    assert.expect(6);
+    TestObject = class MyTestClassOjbect extends EmberObject {
+      @queryManager({ service: 'overridden-apollo' }) apollo;
+
+      willDestroy() {
+        assert.ok(true, 'Should have called the original willDestroy');
+      }
+    };
+
+    let subject = this.subject();
+    assert.equal(unsubscribeCalled, 0, 'should have been initialized with 0');
+
+    subject.apollo.watchQuery({ query: 'fakeQuery' });
+    subject.apollo.watchQuery({ query: 'fakeQuery' });
+
+    subject.willDestroy();
+
+    assert.equal(
+      unsubscribeCalled,
+      2,
+      '_apolloUnsubscribe() was called once per watchQuery'
+    );
+  });
+});

--- a/tests/unit/-private/query-manager-hooks-route-test.js
+++ b/tests/unit/-private/query-manager-hooks-route-test.js
@@ -1,0 +1,115 @@
+import { queryManager } from 'ember-apollo-client';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import ApolloService from 'ember-apollo-client/services/apollo';
+import Route from '@ember/routing/route';
+
+let unsubscribeCalled;
+let assertDeepEqual;
+
+let TestObject = Route.extend({
+  apollo: queryManager({ service: 'overridden-apollo' }),
+});
+
+let OverriddenApollo = class extends ApolloService {
+  managedWatchQuery(manager, opts) {
+    assertDeepEqual(opts, { query: 'fakeQuery' });
+
+    manager.trackSubscription({
+      unsubscribe() {
+        unsubscribeCalled++;
+      },
+    });
+  }
+
+  managedSubscribe(manager, opts) {
+    assertDeepEqual(opts, { query: 'fakeSubscription' });
+
+    manager.trackSubscription({
+      unsubscribe() {
+        unsubscribeCalled++;
+      },
+    });
+  }
+};
+
+module('Unit | queryManager | Setup Hooks in route', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function(assert) {
+    assertDeepEqual = assert.deepEqual.bind(assert);
+    unsubscribeCalled = 0;
+
+    this.subject = function() {
+      this.owner.register('service:overridden-apollo', OverriddenApollo);
+      this.owner.register('test-container:test-object', TestObject);
+      return this.owner.lookup('test-container:test-object');
+    };
+  });
+
+  test('it unsubscribes from any watchQuery subscriptions with isExiting=true', function(assert) {
+    let subject = this.subject();
+
+    assert.equal(unsubscribeCalled, 0, 'should have been initialized with 0');
+    subject.apollo.watchQuery({ query: 'fakeQuery' });
+    subject.apollo.watchQuery({ query: 'fakeQuery' });
+
+    subject.beforeModel();
+    subject.resetController({}, true);
+    assert.equal(
+      unsubscribeCalled,
+      2,
+      '_apolloUnsubscribe() was called once per watchQuery'
+    );
+  });
+
+  test('it unsubscribes from any subscriptions', function(assert) {
+    let subject = this.subject();
+
+    assert.equal(unsubscribeCalled, 0, 'should have been initialized with 0');
+    subject.apollo.subscribe({ query: 'fakeSubscription' });
+    subject.apollo.subscribe({ query: 'fakeSubscription' });
+
+    subject.beforeModel();
+    subject.resetController({}, true);
+    assert.equal(
+      unsubscribeCalled,
+      2,
+      '_apolloUnsubscribe() was called once per subscribe'
+    );
+  });
+
+  test('it only unsubscribes from stale watchQuery subscriptions with isExiting=false', function(assert) {
+    let subject = this.subject();
+
+    assert.equal(unsubscribeCalled, 0, 'should have been initialized with 0');
+    subject.apollo.watchQuery({ query: 'fakeQuery' });
+
+    // simulate data being re-fetched, as when query params change
+    subject.beforeModel();
+    subject.apollo.watchQuery({ query: 'fakeQuery' });
+
+    subject.resetController({}, false);
+    assert.equal(
+      unsubscribeCalled,
+      1,
+      '_apolloUnsubscribe() was called only once, for the first query'
+    );
+  });
+
+  test('it unsubscribes from any watchQuery subscriptions on willDestroy', function(assert) {
+    let subject = this.subject();
+
+    assert.equal(unsubscribeCalled, 0, 'should have been initialized with 0');
+    subject.apollo.watchQuery({ query: 'fakeQuery' });
+    subject.apollo.watchQuery({ query: 'fakeQuery' });
+
+    subject.beforeModel();
+    subject.willDestroy();
+    assert.equal(
+      unsubscribeCalled,
+      2,
+      '_apolloUnsubscribe() was called once per watchQuery'
+    );
+  });
+});

--- a/tests/unit/-private/query-manager-macro-decorator-test.js
+++ b/tests/unit/-private/query-manager-macro-decorator-test.js
@@ -3,6 +3,7 @@ import { queryManager, QueryManager } from 'ember-apollo-client';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import ApolloService from 'ember-apollo-client/services/apollo';
+import { gte } from 'ember-compatibility-helpers';
 
 class OverriddenApollo extends ApolloService {}
 
@@ -37,37 +38,39 @@ module('Unit | queryManager | macro - decorator', function(hooks) {
     );
   });
 
-  test('it works using decorator syntax without options', function(assert) {
-    TestObject = class MyTestClassOjbect extends EmberObject {
-      @queryManager apollo;
-    };
+  if (gte('3.10.0')) {
+    test('it works using decorator syntax without options', function(assert) {
+      TestObject = class MyTestClassOjbect extends EmberObject {
+        @queryManager apollo;
+      };
 
-    let subject = this.subject();
-    assert.ok(subject.apollo, 'should create a apollo property');
-    assert.ok(
-      subject.apollo instanceof QueryManager,
-      'it should be an instance of the query manager'
-    );
-    assert.ok(
-      subject.apollo.apollo instanceof ApolloService,
-      'it should be an instance of the apollo service'
-    );
-  });
+      let subject = this.subject();
+      assert.ok(subject.apollo, 'should create a apollo property');
+      assert.ok(
+        subject.apollo instanceof QueryManager,
+        'it should be an instance of the query manager'
+      );
+      assert.ok(
+        subject.apollo.apollo instanceof ApolloService,
+        'it should be an instance of the apollo service'
+      );
+    });
 
-  test('it works using decorator syntax with options', function(assert) {
-    TestObject = class MyTestClassOjbect extends EmberObject {
-      @queryManager({ service: 'overridden-apollo' }) apollo;
-    };
+    test('it works using decorator syntax with options', function(assert) {
+      TestObject = class MyTestClassOjbect extends EmberObject {
+        @queryManager({ service: 'overridden-apollo' }) apollo;
+      };
 
-    let subject = this.subject();
-    assert.ok(subject.apollo, 'should create a apollo property');
-    assert.ok(
-      subject.apollo instanceof QueryManager,
-      'it should be an instance of the query manager'
-    );
-    assert.ok(
-      subject.apollo.apollo instanceof OverriddenApollo,
-      'the apollo service should be an instance of the overridden apollo service'
-    );
-  });
+      let subject = this.subject();
+      assert.ok(subject.apollo, 'should create a apollo property');
+      assert.ok(
+        subject.apollo instanceof QueryManager,
+        'it should be an instance of the query manager'
+      );
+      assert.ok(
+        subject.apollo.apollo instanceof OverriddenApollo,
+        'the apollo service should be an instance of the overridden apollo service'
+      );
+    });
+  }
 });

--- a/tests/unit/-private/query-manager-macro-decorator-test.js
+++ b/tests/unit/-private/query-manager-macro-decorator-test.js
@@ -1,0 +1,73 @@
+import EmberObject from '@ember/object';
+import { queryManager, QueryManager } from 'ember-apollo-client';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import ApolloService from 'ember-apollo-client/services/apollo';
+
+class OverriddenApollo extends ApolloService {}
+
+let TestObject;
+
+module('Unit | queryManager | macro - decorator', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.owner.register('service:overridden-apollo', OverriddenApollo);
+
+    this.subject = function() {
+      this.owner.register('test-container:test-object', TestObject);
+      return this.owner.lookup('test-container:test-object');
+    };
+  });
+
+  test('it works in a regular ember object', function(assert) {
+    TestObject = EmberObject.extend({
+      apollo: queryManager({ service: 'overridden-apollo' }),
+    });
+
+    let subject = this.subject();
+    assert.ok(subject.apollo, 'should create a apollo property');
+    assert.ok(
+      subject.apollo instanceof QueryManager,
+      'it should be an instance of the query manager'
+    );
+    assert.ok(
+      subject.apollo.apollo instanceof OverriddenApollo,
+      'the apollo service should be an instance of the overridden apollo service'
+    );
+  });
+
+  test('it works using decorator syntax without options', function(assert) {
+    TestObject = class MyTestClassOjbect extends EmberObject {
+      @queryManager apollo;
+    };
+
+    let subject = this.subject();
+    assert.ok(subject.apollo, 'should create a apollo property');
+    assert.ok(
+      subject.apollo instanceof QueryManager,
+      'it should be an instance of the query manager'
+    );
+    assert.ok(
+      subject.apollo.apollo instanceof ApolloService,
+      'it should be an instance of the apollo service'
+    );
+  });
+
+  test('it works using decorator syntax with options', function(assert) {
+    TestObject = class MyTestClassOjbect extends EmberObject {
+      @queryManager({ service: 'overridden-apollo' }) apollo;
+    };
+
+    let subject = this.subject();
+    assert.ok(subject.apollo, 'should create a apollo property');
+    assert.ok(
+      subject.apollo instanceof QueryManager,
+      'it should be an instance of the query manager'
+    );
+    assert.ok(
+      subject.apollo.apollo instanceof OverriddenApollo,
+      'the apollo service should be an instance of the overridden apollo service'
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -707,6 +707,26 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@ember-decorators/object@^5.1.4":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/object/-/object-5.2.0.tgz#48307792b0f8981b637de0229716b890ca0c5be2"
+  integrity sha512-lKqwQ18DHT9TQCLQK6gyeskImaZBhe6C2qjD3wfbZDNxgn3FZI0u2GTSx5JZ3j8AraSHm/qT+1hOkUyktNBQsw==
+  dependencies:
+    "@ember-decorators/utils" "^5.2.0"
+    ember-cli-babel "^7.1.3"
+    ember-compatibility-helpers "^1.1.2"
+
+"@ember-decorators/utils@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/utils/-/utils-5.2.0.tgz#75c79b6d2b69b7d9224a3697176bc198d4e274a9"
+  integrity sha512-GjVPkvqprQNOtsut16Nk3M/UWmqCDDFVSfvUyqasaPlYt9+d6w0y6XrjSnQ6+3VOyk4rUWE+3u0tJoukgeWVLw==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-babel "^7.1.3"
+    ember-cli-version-checker "^3.0.0"
+    ember-compatibility-helpers "^1.1.2"
+    semver "^6.0.0"
+
 "@ember/optional-features@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@ember/optional-features/-/optional-features-0.7.0.tgz#f65a858007020ddfb8342f586112750c32abd2d9"
@@ -1742,7 +1762,7 @@ babel-plugin-debug-macros@^0.1.10:
   dependencies:
     semver "^5.3.0"
 
-babel-plugin-debug-macros@^0.2.0-beta.6:
+babel-plugin-debug-macros@^0.2.0, babel-plugin-debug-macros@^0.2.0-beta.6:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz#0120ac20ce06ccc57bf493b667cf24b85c28da7a"
   integrity sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==
@@ -4037,7 +4057,34 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3, ember-cli-babel@^7.8.0:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.3, ember-cli-babel@^7.7.3:
+  version "7.7.3"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.7.3.tgz#f94709f6727583d18685ca6773a995877b87b8a0"
+  integrity sha512-/LWwyKIoSlZQ7k52P+6agC7AhcOBqPJ5C2u27qXHVVxKvCtg6ahNuRk/KmfZmV4zkuw4EjTZxfJE1PzpFyHkXg==
+  dependencies:
+    "@babel/core" "^7.0.0"
+    "@babel/plugin-proposal-class-properties" "^7.3.4"
+    "@babel/plugin-proposal-decorators" "^7.3.0"
+    "@babel/plugin-transform-modules-amd" "^7.0.0"
+    "@babel/plugin-transform-runtime" "^7.2.0"
+    "@babel/polyfill" "^7.0.0"
+    "@babel/preset-env" "^7.0.0"
+    "@babel/runtime" "^7.2.0"
+    amd-name-resolver "^1.2.1"
+    babel-plugin-debug-macros "^0.3.0"
+    babel-plugin-ember-modules-api-polyfill "^2.8.0"
+    babel-plugin-module-resolver "^3.1.1"
+    broccoli-babel-transpiler "^7.1.2"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.1"
+    broccoli-source "^1.1.0"
+    clone "^2.1.2"
+    ember-cli-babel-plugin-helpers "^1.1.0"
+    ember-cli-version-checker "^2.1.2"
+    ensure-posix-path "^1.0.2"
+    semver "^5.5.0"
+
+ember-cli-babel@^7.1.2, ember-cli-babel@^7.7.0, ember-cli-babel@^7.8.0:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.8.0.tgz#e596500eca0f5a7c9aaee755f803d1542f578acf"
   integrity sha512-xUBgJQ81fqd7k/KIiGU+pjpoXhrmmRf9pUrqLenNSU5N+yeNFT5a1+w0b+p1F7oBphfXVwuxApdZxrmAHOdA3Q==
@@ -4193,7 +4240,7 @@ ember-cli-uglify@^3.0.0:
     broccoli-uglify-sourcemap "^3.1.0"
     lodash.defaultsdeep "^4.6.0"
 
-ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.2:
+ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.1, ember-cli-version-checker@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz#47771b731fe0962705e27c8199a9e3825709f3b3"
   integrity sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==
@@ -4306,6 +4353,15 @@ ember-cli@~3.11.0:
     walk-sync "^1.1.3"
     watch-detector "^0.1.0"
     yam "^1.0.0"
+
+ember-compatibility-helpers@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.0.tgz#feee16c5e9ef1b1f1e53903b241740ad4b01097e"
+  integrity sha512-pUW4MzJdcaQtwGsErYmitFRs0rlCYBAnunVzlFFUBr4xhjlCjgHJo0b53gFnhTgenNM3d3/NqLarzRhDTjXRTg==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^2.1.1"
+    semver "^5.4.1"
 
 ember-disable-prototype-extensions@^1.1.3:
   version "1.1.3"
@@ -8975,7 +9031,12 @@ schema-utils@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
-semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2:
+semver@^6.0.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.1.tgz#53f53da9b30b2103cd4f15eab3a18ecbcb210c9b"
+  integrity sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==
+
+semver@^6.1.0, semver@^6.1.1, semver@^6.1.2:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1783,7 +1783,7 @@ babel-plugin-dynamic-import-node@^2.3.0:
   dependencies:
     object.assign "^4.1.0"
 
-babel-plugin-ember-modules-api-polyfill@^2.6.0, babel-plugin-ember-modules-api-polyfill@^2.9.0:
+babel-plugin-ember-modules-api-polyfill@^2.6.0, babel-plugin-ember-modules-api-polyfill@^2.8.0, babel-plugin-ember-modules-api-polyfill@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.9.0.tgz#8503e7b4192aeb336b00265e6235258ff6b754aa"
   integrity sha512-c03h50291phJ2gQxo/aIOvFQE2c6glql1A7uagE3XbPXpKVAJOUxtVDjvWG6UAB6BC5ynsJfMWvY0w4TPRKIHQ==
@@ -4354,7 +4354,7 @@ ember-cli@~3.11.0:
     watch-detector "^0.1.0"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.1.2:
+ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.0.tgz#feee16c5e9ef1b1f1e53903b241740ad4b01097e"
   integrity sha512-pUW4MzJdcaQtwGsErYmitFRs0rlCYBAnunVzlFFUBr4xhjlCjgHJo0b53gFnhTgenNM3d3/NqLarzRhDTjXRTg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -707,25 +707,20 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-decorators/object@^5.1.4":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/object/-/object-5.2.0.tgz#48307792b0f8981b637de0229716b890ca0c5be2"
-  integrity sha512-lKqwQ18DHT9TQCLQK6gyeskImaZBhe6C2qjD3wfbZDNxgn3FZI0u2GTSx5JZ3j8AraSHm/qT+1hOkUyktNBQsw==
+"@ember-decorators/object@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/object/-/object-6.0.0.tgz#79dc37e803b5da64e21346444d0cb3d3825224fa"
+  integrity sha512-VK4PT1fBZB0SPd+6f1YVyNw9PO5vK/wV05lIANVmvjE8SHP09ig1z04ajBujQMJtbQBFbTfwwnxtBAOfNUNr5g==
   dependencies:
-    "@ember-decorators/utils" "^5.2.0"
+    "@ember-decorators/utils" "^6.0.0"
     ember-cli-babel "^7.1.3"
-    ember-compatibility-helpers "^1.1.2"
 
-"@ember-decorators/utils@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/utils/-/utils-5.2.0.tgz#75c79b6d2b69b7d9224a3697176bc198d4e274a9"
-  integrity sha512-GjVPkvqprQNOtsut16Nk3M/UWmqCDDFVSfvUyqasaPlYt9+d6w0y6XrjSnQ6+3VOyk4rUWE+3u0tJoukgeWVLw==
+"@ember-decorators/utils@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/utils/-/utils-6.0.0.tgz#94ac94ce03b607fc0d2d6a058b9a27e20735ec8e"
+  integrity sha512-moW4Oa7X1CN15LvjHlJVuwI4PpwTjXTPHPCCJll+a0X1sowQhObcLRykn6OMwdm9naCROGnRmcwpVqnE0eFjBg==
   dependencies:
-    babel-plugin-debug-macros "^0.2.0"
     ember-cli-babel "^7.1.3"
-    ember-cli-version-checker "^3.0.0"
-    ember-compatibility-helpers "^1.1.2"
-    semver "^6.0.0"
 
 "@ember/optional-features@^0.7.0":
   version "0.7.0"
@@ -1783,7 +1778,7 @@ babel-plugin-dynamic-import-node@^2.3.0:
   dependencies:
     object.assign "^4.1.0"
 
-babel-plugin-ember-modules-api-polyfill@^2.6.0, babel-plugin-ember-modules-api-polyfill@^2.8.0, babel-plugin-ember-modules-api-polyfill@^2.9.0:
+babel-plugin-ember-modules-api-polyfill@^2.6.0, babel-plugin-ember-modules-api-polyfill@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.9.0.tgz#8503e7b4192aeb336b00265e6235258ff6b754aa"
   integrity sha512-c03h50291phJ2gQxo/aIOvFQE2c6glql1A7uagE3XbPXpKVAJOUxtVDjvWG6UAB6BC5ynsJfMWvY0w4TPRKIHQ==
@@ -3974,9 +3969,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.191, electron-to-chromium@^1.3.47:
-  version "1.3.209"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.209.tgz#cd43879f1d3fb85c75bb843fb11a828570fa1ce4"
-  integrity sha512-KxRvLp5jUapyKIcMaecwgmUpJEsJKuHn0DJJPZjZh2valqYlzdmGvaE/nTAqwKqQwf0jIKv7Go4FYHu9wKWzOg==
+  version "1.3.210"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.210.tgz#0ce6247366c5771d4f5663a5879388fd1adefb7e"
+  integrity sha512-m1i/F+gw9jkauxDx0mOr7Sj6vp6se1mfkQNYqZb1yL5VGTp0AC1NZH5CGI6YMSO7WaScILmkKDZFG9/hlR9axQ==
 
 elliptic@^6.0.0:
   version "6.5.0"
@@ -4057,34 +4052,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.3, ember-cli-babel@^7.7.3:
-  version "7.7.3"
-  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.7.3.tgz#f94709f6727583d18685ca6773a995877b87b8a0"
-  integrity sha512-/LWwyKIoSlZQ7k52P+6agC7AhcOBqPJ5C2u27qXHVVxKvCtg6ahNuRk/KmfZmV4zkuw4EjTZxfJE1PzpFyHkXg==
-  dependencies:
-    "@babel/core" "^7.0.0"
-    "@babel/plugin-proposal-class-properties" "^7.3.4"
-    "@babel/plugin-proposal-decorators" "^7.3.0"
-    "@babel/plugin-transform-modules-amd" "^7.0.0"
-    "@babel/plugin-transform-runtime" "^7.2.0"
-    "@babel/polyfill" "^7.0.0"
-    "@babel/preset-env" "^7.0.0"
-    "@babel/runtime" "^7.2.0"
-    amd-name-resolver "^1.2.1"
-    babel-plugin-debug-macros "^0.3.0"
-    babel-plugin-ember-modules-api-polyfill "^2.8.0"
-    babel-plugin-module-resolver "^3.1.1"
-    broccoli-babel-transpiler "^7.1.2"
-    broccoli-debug "^0.6.4"
-    broccoli-funnel "^2.0.1"
-    broccoli-source "^1.1.0"
-    clone "^2.1.2"
-    ember-cli-babel-plugin-helpers "^1.1.0"
-    ember-cli-version-checker "^2.1.2"
-    ensure-posix-path "^1.0.2"
-    semver "^5.5.0"
-
-ember-cli-babel@^7.1.2, ember-cli-babel@^7.7.0, ember-cli-babel@^7.8.0:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3, ember-cli-babel@^7.8.0:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.8.0.tgz#e596500eca0f5a7c9aaee755f803d1542f578acf"
   integrity sha512-xUBgJQ81fqd7k/KIiGU+pjpoXhrmmRf9pUrqLenNSU5N+yeNFT5a1+w0b+p1F7oBphfXVwuxApdZxrmAHOdA3Q==
@@ -4354,7 +4322,7 @@ ember-cli@~3.11.0:
     watch-detector "^0.1.0"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0:
+ember-compatibility-helpers@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.0.tgz#feee16c5e9ef1b1f1e53903b241740ad4b01097e"
   integrity sha512-pUW4MzJdcaQtwGsErYmitFRs0rlCYBAnunVzlFFUBr4xhjlCjgHJo0b53gFnhTgenNM3d3/NqLarzRhDTjXRTg==
@@ -8832,9 +8800,9 @@ resolve@1.9.0:
     path-parse "^1.0.6"
 
 resolve@^1.1.3, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.7.1, resolve@^1.8.1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
-  integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
+  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
   dependencies:
     path-parse "^1.0.6"
 
@@ -9031,12 +8999,7 @@ schema-utils@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
-semver@^6.0.0:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.1.tgz#53f53da9b30b2103cd4f15eab3a18ecbcb210c9b"
-  integrity sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==
-
-semver@^6.1.0, semver@^6.1.1, semver@^6.1.2:
+semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==


### PR DESCRIPTION
Closes #139.

**Details**

This uses an Ember `computed` as it allows us to use computed as a macro in classic Ember Objects as well as a decorator when using classes on Ember v3.10 or above.

**This deprecates mixins entirely**. Everything that we could do before using mixins can be accomplished by using `queryManager`.

Huge thanks to @buschtoens for the original idea and @tchak for the initial implementation in his branch https://github.com/tchak/ember-apollo-client/tree/drop-mixins. 
