### PR TITLE
Allow resultKey to be a function

### DIFF
--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -44,6 +44,10 @@ function extractNewData(resultKey, { data, loading }) {
     return null;
   }
   let keyedData = isNone(resultKey) ? data : data && get(data, resultKey);
+  
+  if (typeof resultKey === 'function'){
+    keyedData = resultKey(keyedData);
+  }
 
   return copyWithExtras(keyedData || {}, [], []);
 }


### PR DESCRIPTION
How do you think if the resultKey could be a function?

My use case is to transform the value of `watchQuery` every time there is new data. My goal is to augment the data with some extra properties that are not present on the graphql json.

Currently my workaround is do something like the following:
```
apollo
      .watchQuery(params, 'children')
      .then(children => {
        children
          .addArrayObserver({
            arrayDidChange: arr => arr.forEach(augmentChild)
          })
        children.forEach(augmentChild)
        return children
      })
```

With this feature I would be able to rewrite to:
```
apollo
      .watchQuery(params, data => data.children.map(augmentChild))
```