### PR TITLE
Don't create EmberObject for returned data & Add public alternative to unsubscribe from watchQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Breaking
 
-- Upgrade broccoli-graphql-filter to allow new import syntax
-- It's not recommended to import dependencies of other dependencies in your
+- Don't create EmberObject for returned data:
+  Before this change, `ember-apollo-client` would always wrap the returned data
+  from the GraphQL (when not an array) with `EmberObject`. In this PR we removed
+  that and instead we return plain objects.
+- Remove unused prod dependencies:
+    It's not recommended to import dependencies of other dependencies in your
     application. Therefore, if you depend on any apollo package that this
     addons depends on, you should add to your `package.json`. You should also add
     ember-auto-import to make sure you are able to import them.
+
+### Added
+
+- Upgrade broccoli-graphql-filter to allow new import syntax
+- Add public alternative to unsubscribe from watchQuery
+  Before the recommended way was to access a property `_apolloUnsubscribe` from
+  the result query.
 
 
 ## [v2.0.0-beta.5] - 2019-08-19

--- a/README.md
+++ b/README.md
@@ -537,13 +537,32 @@ Apollo Client's `watchQuery` will continue to update the query with new data
 whenever the store is updated with new data about the resolved objects. This
 happens until you explicitly unsubscribe from it.
 
-In ember-apollo-client, most unsubscriptions are handled automatically by the
+In `ember-apollo-client`, most unsubscriptions are handled automatically by the
 `queryManager` computed macro, so long as you use it.
 
 If you're fetching data elsewhere, such as in an Ember Service, or if you use
 the Apollo service directly, you are responsible for unsubscribing from
-`watchQuery` results when you're done with them. This is exposed on the
-result of `query` via a method `_apolloUnsubscribe`.
+`watchQuery` results when you're done with them, you can use `unsubscribe`:
+
+```js
+import Service from "@ember/service";
+import { unsubscribe } from "ember-apollo-client";
+import { inject as service } from '@ember/service';
+
+export default Service.extend( {
+  apollo: service(),
+  result: null,
+
+  init() {
+    this._super(...arguments);
+    this.result = this.apollo.watchQuery(...);
+  },
+
+  willDestroy() {
+    unsubscribe(this.result)
+  }
+});
+```
 
 ### queryManager as decorator
 

--- a/README.md
+++ b/README.md
@@ -364,15 +364,10 @@ mutation createReview($ep: Episode!, $review: ReviewInput!) {
 ```js
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
-import EmberObject from "@ember/object";
 import mutation from "my-app/gql/mutations/create-review";
 
 export default Route.extend({
   apollo: service(),
-
-  model() {
-    return EmberObject.create({});
-  },
 
   actions: {
     createReview(ep, review) {

--- a/addon/index.js
+++ b/addon/index.js
@@ -3,11 +3,20 @@ import ObjectQueryManager from './-private/mixins/object-query-manager';
 import RouteQueryManager from './-private/mixins/route-query-manager';
 import QueryManager, { queryManager } from './-private/apollo/query-manager';
 
+export let apolloObservableKey = '_apolloObservable';
+export let apolloUnsubscribeKey = '_apolloUnsubscribe';
+
 export function getObservable(queryResult) {
-  return queryResult._apolloObservable;
+  return queryResult[apolloObservableKey];
 }
 
-export let apolloObservableKey = '_apolloObservable';
+export function unsubscribe(queryResult) {
+  let fn = queryResult[apolloUnsubscribeKey];
+
+  if (typeof fn === 'function') {
+    return fn();
+  }
+}
 
 export {
   queryManager,

--- a/tests/acceptance/array-watch-query-test.js
+++ b/tests/acceptance/array-watch-query-test.js
@@ -1,0 +1,69 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'dummy/tests/helpers/setup';
+import { addResolveFunctionsToSchema } from 'graphql-tools';
+import { click, currentURL, find, findAll, visit } from '@ember/test-helpers';
+
+const mockReviews = [
+  {
+    stars: 3,
+    commentary: 'Nice!',
+    __typename: 'Review',
+  },
+];
+
+module('Acceptance | array watchQuery', function(hooks) {
+  setupApplicationTest(hooks);
+
+  let schema;
+
+  hooks.beforeEach(function() {
+    schema = this.pretender.schema;
+  });
+
+  test('should re-render updating an array using watchQuery', async function(assert) {
+    let resolvers = {
+      Query: {
+        reviews(/*obj, args*/) {
+          return new Promise(resolve => {
+            setTimeout(() => {
+              resolve(mockReviews);
+            }, 200);
+          });
+        },
+      },
+    };
+
+    addResolveFunctionsToSchema({ schema, resolvers });
+
+    await visit('/reviews');
+    assert.equal(currentURL(), '/reviews');
+
+    assert.equal(findAll('.reviews-list li').length, 1, 'has one item');
+    assert.equal(find('.model-stars').innerText, '3', 'has correct stars');
+
+    mockReviews[0].stars = 2;
+    mockReviews.push({
+      stars: 5,
+      commentary: 'Awesome!',
+    });
+
+    await click('.refetch-data');
+    assert.equal(
+      findAll('.reviews-list li').length,
+      2,
+      'should have updated the list'
+    );
+
+    assert.equal(
+      findAll('.model-stars')[0].innerText,
+      '2',
+      'has correct updated stars'
+    );
+
+    assert.equal(
+      findAll('.model-stars')[1].innerText,
+      '5',
+      'has correct stars for new data'
+    );
+  });
+});

--- a/tests/dummy/app/gql/queries/reviews.graphql
+++ b/tests/dummy/app/gql/queries/reviews.graphql
@@ -1,0 +1,6 @@
+query {
+  reviews(episode: NEWHOPE) {
+    stars
+    commentary
+  }
+}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -11,6 +11,7 @@ Router.map(function() {
   this.route('luke');
   this.route('anakin');
   this.route('new-review');
+  this.route('reviews');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/reviews.js
+++ b/tests/dummy/app/routes/reviews.js
@@ -1,0 +1,18 @@
+import Route from '@ember/routing/route';
+import query from 'dummy/gql/queries/reviews';
+import { queryManager, getObservable } from 'ember-apollo-client';
+
+export default Route.extend({
+  apollo: queryManager(),
+
+  model() {
+    return this.apollo.watchQuery({ query }, 'reviews');
+  },
+
+  actions: {
+    refetchData(model) {
+      const observable = getObservable(model);
+      observable.refetch();
+    },
+  },
+});

--- a/tests/dummy/app/templates/reviews.hbs
+++ b/tests/dummy/app/templates/reviews.hbs
@@ -1,0 +1,15 @@
+<button
+  {{action "refetchData" model}}
+  class="refetch-data"
+>
+  Refetch
+</button>
+
+<ul class="reviews-list">
+  {{#each model as |item|}}
+    <li>
+      <span class="model-stars">{{item.stars}}</span>:
+      <span class="model-commentary">{{item.commentary}}</span>
+    </li>
+  {{/each}}
+</ul>

--- a/tests/unit/get-observable-test.js
+++ b/tests/unit/get-observable-test.js
@@ -1,13 +1,12 @@
-import EmberObject from '@ember/object';
 import { getObservable } from 'ember-apollo-client';
 import { module, test } from 'qunit';
 
 module('Unit | getObservable', function() {
   test('it should return the observable from a result object', function(assert) {
     let mockObservable = { fakeObservable: true };
-    let resultObject = EmberObject.create({
+    let resultObject = {
       _apolloObservable: mockObservable,
-    });
+    };
 
     let result = getObservable(resultObject);
     assert.deepEqual(result, mockObservable);

--- a/tests/unit/unsubscribe-test.js
+++ b/tests/unit/unsubscribe-test.js
@@ -1,0 +1,17 @@
+import { unsubscribe } from 'ember-apollo-client';
+import { module, test } from 'qunit';
+
+module('Unit | unsubscribe', function() {
+  test('it should call the unsubscribe function', function(assert) {
+    assert.expect(1);
+
+    let mockUnsubscribe = () => {
+      assert.ok('should have been called');
+    };
+    let resultObject = {
+      _apolloUnsubscribe: mockUnsubscribe,
+    };
+
+    unsubscribe(resultObject);
+  });
+});


### PR DESCRIPTION
## Breaking: 

- Don't create EmberObject for returned data:
  Before this change, `ember-apollo-client` would always wrap the returned data from the GraphQL (when not an array) with `EmberObject`. In this PR we removed that and instead we return plain objects.

## Added
- Add tests on watchQuery returning arrays.
- Add public alternative to unsubscribe from watchQuery
  Before the recommended way was to access a property `_apolloUnsubscribe` from the result query.