### PR TITLE
Remove usage of Evented mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Before this change, `ember-apollo-client` would always wrap the returned data
   from the GraphQL (when not an array) with `EmberObject`. In this PR we removed
   that and instead we return plain objects.
+
+- Remove usage of Evented mixin: `subscribe` no longer returns an Ember Object and
+    does not apply the Evented Ember mixin. Instead, it just returns an native class and
+    it triggers an event when new data comes in. You can use this event to add
+    a listener like so:
+
+  ```js
+  //import { addListener, removeListener } from '@ember/object/events';
+
+  const result = await this.apollo.subscribe(
+    {
+      subscription: mySubscription,
+    }
+  );
+
+  const handleEvent = event => {
+    console.log('event received', event)
+  };
+
+  // Add listener to new data
+  addListener(result, 'event', handleEvent);
+
+  // Remove the listener from new data
+  removeListener(result, 'event', handleEvent);
+  ```
+
+  The `lastEvent` property should be accessed directly or use `get` from Ember
+  Object.
+
+  ```js
+  console.log(result.lastEvent);
+
+  // or
+
+  // import { get } from '@ember/object';
+
+  console.log(get(result, 'lastEvent'));
+  ```
+
 - Remove unused prod dependencies:
     It's not recommended to import dependencies of other dependencies in your
     application. Therefore, if you depend on any apollo package that this

--- a/README.md
+++ b/README.md
@@ -391,8 +391,27 @@ export default Route.extend({
   [`ApolloClient.subscribe`][subscribe] method. It returns a promise that
   resolves with an `EmberApolloSubscription`. You can use this object in a few ways to keep
   track of your subscription:
-  - emberApolloSubscription.on('event', event => do_something_with(event)); // manually act on event
-  - emberApolloSubscription.get('lastEvent'); // return the most recently received event data
+  - emberApolloSubscription.lastEvent; // return the most recently received event data
+
+  ```js
+  //import { addListener, removeListener } from '@ember/object/events';
+
+  const result = await this.apollo.subscribe(
+    {
+      subscription: mySubscription,
+    }
+  );
+
+  const handleEvent = event => {
+    console.log('event received', event)
+  };
+
+  // Add listener to new data
+  addListener(result, 'event', handleEvent);
+
+  // Remove the listener from new data
+  removeListener(result, 'event', handleEvent);
+  ```
 
   As before, the `resultKey` can be used to resolve beneath the root.
 

--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import EmberObject, { get, setProperties } from '@ember/object';
-import Evented from '@ember/object/evented';
+import { get, set, setProperties } from '@ember/object';
+import { sendEvent } from '@ember/object/events';
 import RSVP from 'rsvp';
 import Service from '@ember/service';
 import fetch from 'fetch';
@@ -20,18 +20,17 @@ import {
   QueryManager,
 } from '../index';
 
-class EmberApolloSubscription extends EmberObject.extend(Evented) {
+class EmberApolloSubscription {
   lastEvent = null;
+  _apolloClientSubscription = null;
 
   apolloUnsubscribe() {
     this._apolloClientSubscription.unsubscribe();
   }
 
-  _apolloClientSubscription = null;
-
   _onNewData(newData) {
-    this.set('lastEvent', newData);
-    this.trigger('event', newData);
+    set(this, 'lastEvent', newData);
+    sendEvent(this, 'event', [newData]);
   }
 }
 
@@ -255,7 +254,7 @@ export default class ApolloService extends Service {
   subscribe(opts, resultKey = null) {
     const observable = this.client.subscribe(opts);
 
-    const obj = EmberApolloSubscription.create();
+    const obj = new EmberApolloSubscription();
 
     return this._waitFor(
       new RSVP.Promise((resolve, reject) => {
@@ -274,7 +273,7 @@ export default class ApolloService extends Service {
           },
         });
 
-        obj.set('_apolloClientSubscription', subscription);
+        obj._apolloClientSubscription = subscription;
 
         resolve(obj);
       })

--- a/tests/unit/services/apollo-test.js
+++ b/tests/unit/services/apollo-test.js
@@ -9,6 +9,7 @@ import { computed } from '@ember/object';
 import { createHttpLink } from 'apollo-link-http';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import fetch from 'fetch';
+import { addListener, removeListener } from '@ember/object/events';
 
 let fakeLink = () => {};
 
@@ -131,7 +132,11 @@ module('Unit | Service | apollo', function(hooks) {
     );
 
     const names = [];
-    result.on('event', e => names.push(e.name));
+    const handleEvent = event => {
+      names.push(event.name);
+    };
+
+    addListener(result, 'event', handleEvent);
 
     // Things initialize as empty
     assert.equal(result.lastEvent, null);
@@ -152,6 +157,7 @@ module('Unit | Service | apollo', function(hooks) {
     // Still have last event
     assert.equal(result.lastEvent.name, '3 Greg');
     assert.equal(names.join(' '), '1 Link 2 Luke 3 Greg');
+    removeListener(result, 'event', handleEvent);
   });
 
   test('it works when cache and link are computed properties, deprecated computed', function(assert) {


### PR DESCRIPTION
Implements #311. 

**Remove usage of Evented mixin:** `subscribe` no longer returns an Ember Object and
does not apply the Evented Ember mixin. Instead, it just returns a native class and
it triggers an event when new data comes in. You can use this event to add
a listener like so:

```js
//import { addListener, removeListener } from '@ember/object/events';

const result = await this.apollo.subscribe(
{
  subscription: mySubscription,
}
);

const handleEvent = event => {
console.log('event received', event)
};

// Add listener to new data
addListener(result, 'event', handleEvent);

// Remove the listener from new data
removeListener(result, 'event', handleEvent);
```

The `lastEvent` property should be accessed directly or use `get` from Ember
Object.

```js
console.log(result.lastEvent);

// or

// import { get } from '@ember/object';

console.log(get(result, 'lastEvent'));
```
