### PR TITLE
Add deprecation for for default value of keepGraphqlFileExtension

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ module.exports = function(defaults) {
 
 `keepGraphqlFileExtension = false`, optional – If `true`, creates files called `my-query.graphql.js` instead of `my-query.js`, so that you can import them as `./my-query.graphql` instead of `./my-query`.
 
+Example:
+
+```js
+import myQuery from 'my-app/queries/my-query.graphql';
+```
+
 ### Dependencies
 
 This addon uses [ember-auto-import](https://github.com/ef4/ember-auto-import) to import dependencies.
@@ -148,7 +154,7 @@ const query = gql`
 > **Note:** Inline queries like the one above are compiled at *runtime*. This is
 > both slower than external files (which are precompiled) and involves shipping
 > extra dependencies in your vendor.js. For the time being, we recommend using
-> external files for your queries. 
+> external files for your queries.
 >
 > If you are looking for an opportunity to contribute, enabling precompilation
 > of inline queries would be a fantastic feature to work on.

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,6 +7,9 @@ module.exports = function(defaults) {
     pretender: {
       enabled: true,
     },
+    emberApolloClient: {
+      keepGraphqlFileExtension: false,
+    },
   });
 
   /*

--- a/index.js
+++ b/index.js
@@ -28,6 +28,20 @@ module.exports = {
   },
 
   getOptions() {
+    if (
+      this.app &&
+      (typeof this.app.options.emberApolloClient === 'undefined' ||
+        typeof this.app.options.emberApolloClient.keepGraphqlFileExtension ===
+          'undefined')
+    ) {
+      this.ui.writeDeprecateLine(`[ember-apollo-client] Deprecation:
+        The configuration option keepGraphqlFileExtension was not defined.
+        The current default is 'false', but it will change to 'true' after the next major release.
+        This option allows you to import graphql files using its extension. eg. 'import myQuery from 'my-app/queries/my-query.graphql';'
+        To continue with the current behavior, explicit set it to 'false' in your 'ember-cli-build.js'.
+        Please refer to 'Build time configuration' section in ember-apollo-client's README for more information.`);
+    }
+
     return (
       (this.app && this.app.options.emberApolloClient) || {
         keepGraphqlFileExtension: false,
@@ -37,6 +51,7 @@ module.exports = {
 
   setupPreprocessorRegistry(type, registry) {
     let getOptions = this.getOptions.bind(this);
+    let options = getOptions();
 
     if (type === 'parent') {
       registry.add('js', {
@@ -44,8 +59,6 @@ module.exports = {
         ext: 'graphql',
         toTree(tree) {
           const GraphQLFilter = require('broccoli-graphql-filter');
-
-          let options = getOptions();
 
           return new GraphQLFilter(tree, {
             keepExtension: options.keepGraphqlFileExtension,


### PR DESCRIPTION
```
DEPRECATION: [ember-apollo-client] Deprecation:
        The configuration option keepGraphqlFileExtension was not defined.
        The current default is 'false', but it will change to 'true' after the next major release.
        This option allows you to import graphql files using its extension. eg. 'import myQuery from 'my-app/queries/my-query.graphql';'
        To continue with the current behavior, explicit set it to 'false' in your 'ember-cli-build.js'.
        Please refer to 'Build time configuration' section in ember-apollo-client's README for more information.
```