### PR TITLE
Add tests to make sure refresh a route renders new data

### DIFF
--- a/tests/acceptance/watch-query-test.js
+++ b/tests/acceptance/watch-query-test.js
@@ -87,4 +87,39 @@ module('Acceptance | watch query', function(hooks) {
 
     assert.dom('.movie-title').hasText('The Godfather');
   });
+
+  test('refetch using reoute refresh should update template', async function(assert) {
+    let isRefetch = false;
+    let resolvers = {
+      Query: {
+        movie(_, args) {
+          assert.deepEqual(args, { id: '680' });
+
+          if (isRefetch) {
+            return new Promise(resolve => {
+              setTimeout(() => {
+                resolve(
+                  Object.assign({}, mockMovie, { title: 'The Godfather' })
+                );
+              }, 200);
+            });
+          }
+
+          return Promise.resolve(mockMovie);
+        },
+      },
+    };
+
+    addResolveFunctionsToSchema({ schema: this.pretender.schema, resolvers });
+
+    await visit('/movie/680');
+    assert.equal(currentURL(), '/movie/680');
+
+    assert.dom('.movie-title').hasText('Pulp Fiction');
+
+    isRefetch = true;
+    await click('.refresh-data');
+
+    assert.dom('.movie-title').hasText('The Godfather');
+  });
 });

--- a/tests/dummy/app/routes/movie.js
+++ b/tests/dummy/app/routes/movie.js
@@ -12,16 +12,13 @@ export default Route.extend({
       variables: {
         id,
       },
+      fetchPolicy: 'network-only',
     });
   },
 
   actions: {
-    refetchData(id) {
-      this.apollo.query({
-        query,
-        variables: { id },
-        fetchPolicy: 'network-only',
-      });
+    refreshUsingRoute() {
+      this.refresh();
     },
 
     refetchUsingObservable(model) {

--- a/tests/dummy/app/templates/movie.hbs
+++ b/tests/dummy/app/templates/movie.hbs
@@ -13,17 +13,17 @@
   </button>
 
   <button
-    {{action "refetchData" this.model.movie.id}}
-    class="button refresh-data"
-  >
-    Refetch (new query)
-  </button>
-
-  <button
     {{action "refetchUsingObservable" this.model}}
     class="button refetch-data-using-observable"
   >
     Refetch (using observable)
+  </button>
+
+  <button
+    {{action "refreshUsingRoute"}}
+    class="button refresh-data"
+  >
+    Refetch (using route refresh())
   </button>
 </div>
 


### PR DESCRIPTION
This adds a test to make sure when refreshing a route using `refresh` and new data is returned, we do render it. 

RE: https://github.com/ember-graphql/ember-apollo-client/pull/310#issuecomment-583548829