### PR TITLE
Handle errorPolicy="all" for queries

### DIFF
--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -304,9 +304,23 @@ export default class ApolloService extends Service {
           .query(opts)
           .then((result) => {
             let response = result.data;
-            if (!isNone(resultKey)) {
+            if (!isNone(resultKey) && response) {
               response = get(response, resultKey);
             }
+
+            if (
+              opts.errorPolicy === 'all' &&
+              result.errors &&
+              result.errors.length > 0
+            ) {
+              return reject(
+                new ApolloErrorWithResponse({
+                  response,
+                  errors: result.errors,
+                })
+              );
+            }
+
             return resolve(response);
           })
           .catch((error) => {
@@ -403,5 +417,16 @@ export default class ApolloService extends Service {
       return this._shouldWait();
     };
     registerWaiter(this._waiter);
+  }
+}
+
+export class ApolloErrorWithResponse extends Error {
+  constructor({ response, errors }) {
+    let message = 'The server responded with an error.';
+    super(message);
+
+    this.name = 'ApolloErrorWithResponse';
+    this.response = response;
+    this.errors = errors || [];
   }
 }


### PR DESCRIPTION
In our app, I tried to handle partial errors via `errorPolicy="all"`. However, I noticed that the errors are simply swallowed by ember-apollo-client, making it impossible to see if something happened or not.

This PR is an idea for how this could be solved. It only adds this for `apollo.query()`, not entirely sure what would need to be done for `watchQuery()`.