### PR TITLE
Fix repo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "graphql",
     "graphql-client"
   ],
-  "repository": "https://github.com/bgentry/ember-apollo-client",
+  "repository": "https://github.com/ember-graphql/ember-apollo-client",
   "license": "MIT",
   "author": "Blake Gentry",
   "directories": {


### PR DESCRIPTION
I noticed that this was still pointing to the old repo location. Figured I'd update it to point to the current repo URL instead of the old bgentry one :v:

Also feel free to update `package.json` to reflect the current list of `maintainers` @josemarluedke :pray: