### PR TITLE
Run CI on Pull Requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+      - 'v*'
+  pull_request: {}
 
 jobs:
   test:


### PR DESCRIPTION
CI wasn't been run when PRs were done by non-members of the org.