### PR TITLE
Allow graphql v15 and tell webpack about react

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,9 @@ module.exports = {
             },
           ],
         },
+        externals: {
+          react: 'react',
+        },
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "qunit-dom": "^1.2.0"
   },
   "peerDependencies": {
-    "graphql": "^14.0.2"
+    "graphql": "^14.0.0 || ^15.0.0"
   },
   "engines": {
     "node": "10.* || >= 12"


### PR DESCRIPTION
The Apollo Client v3 has react code in it, which requires react. Ember Auto Import uses webpack, which might try to import react and fail. 