### PR TITLE
Ensure apollo store is cleared when destroying apollo service

### DIFF
--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -110,6 +110,15 @@ export default class ApolloService extends Service {
     }
   }
 
+  willDestroy() {
+    // Ensure watch queries are not refeteched anymore
+    // See: https://www.apollographql.com/docs/react/v2.6/api/apollo-client/#ApolloClient.clearStore
+    // We guard against non-existance mostly to simplify tests a bit here
+    if (typeof this.client.clearStore === 'function') {
+      this.client.clearStore();
+    }
+  }
+
   // options are configured in your environment.js.
   get options() {
     // config:environment not injected into tests, so try to handle that gracefully.


### PR DESCRIPTION
This ensures that the apollo store, including watched queries, are cleared when the apollo service is destroyed. 
This is probably mostly relevant for tests, but it IMHO generally makes sense to do that.

Hopefully fixes https://github.com/ember-graphql/ember-apollo-client/issues/335