### PR TITLE
Spread dataToSend array to allow watchQuery using resultKey to update collection

### DIFF
--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -73,7 +73,7 @@ function newDataFunc(observable, resultKey, resolve, unsubscribeFn = null) {
 
     if (isNone(obj)) {
       if (isArray(dataToSend)) {
-        obj = A(dataToSend);
+        obj = A([...dataToSend]);
       } else {
         obj = { ...dataToSend };
       }


### PR DESCRIPTION
Using a `resultKey` that matches the path of an array with `watchQuery` is throwing errors after recent updates. We are having errors like `Uncaught TypeError: Cannot assign to read only property '0' of object '[object Array]'`, when the watchQuery updates the array collection.

By spreading the collection into a new array, we ensure that the new collection is mutable and that let us update the collection on subsequents watchQuery.