### PR TITLE
Update broccoli-graphql-filter from 0.4.2 to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@apollo/client": "^3.2.1",
     "@ember/test-waiters": "^2.3.0",
-    "broccoli-graphql-filter": "^0.4.2",
+    "broccoli-graphql-filter": "^1.0.0",
     "ember-auto-import": "^1.6.0",
     "ember-cli-babel": "^7.22.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3636,14 +3636,14 @@ broccoli-funnel@^3.0.3:
     path-posix "^1.0.0"
     walk-sync "^2.0.2"
 
-broccoli-graphql-filter@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/broccoli-graphql-filter/-/broccoli-graphql-filter-0.4.2.tgz#d2b18a67a357b553948e645e9a4472817cfb89f0"
-  integrity sha512-7nMWtEdJ6zEZ2F5Qkgo/gddqY24nJh3afZRCL62rOVrrl5uut7XgjDc9nyzQxdYZvkpEUTv82BXzEk3OhZqINw==
+broccoli-graphql-filter@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-graphql-filter/-/broccoli-graphql-filter-1.0.0.tgz#61d74812c91f1cc25b6bff8eb06bd34fd77fd5e2"
+  integrity sha512-FMvZi9HDPM6gPH46oT+YgAoPGG5tYm7YT/tjfhIdovEKl1FUOxFXuImMOor+MDxWxe7ufXqw/Y5Uv55ZCHk4kA==
   dependencies:
-    broccoli-persistent-filter "^2.1.1"
-    graphql "^14.0.2"
+    broccoli-persistent-filter "^3.1.1"
     graphql-tag "^2.10.0"
+    object-hash "^2.0.3"
 
 broccoli-kitchen-sink-helpers@^0.3.1:
   version "0.3.1"
@@ -3744,7 +3744,7 @@ broccoli-persistent-filter@^1.1.6, broccoli-persistent-filter@^1.4.3:
     symlink-or-copy "^1.0.1"
     walk-sync "^0.3.1"
 
-broccoli-persistent-filter@^2.1.1, broccoli-persistent-filter@^2.2.1, broccoli-persistent-filter@^2.2.2, broccoli-persistent-filter@^2.3.0:
+broccoli-persistent-filter@^2.2.1, broccoli-persistent-filter@^2.2.2, broccoli-persistent-filter@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz#4a052e0e0868b344c3a2977e35a3d497aa9eca72"
   integrity sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==
@@ -3768,6 +3768,23 @@ broccoli-persistent-filter@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.1.tgz#318c68a82d5759582bb60e7e2c0f3ca008176224"
   integrity sha512-gP797MF87JjkcwhGBkE0fhF3aIbGnOF3K3A0iZpQSxtpmSNt+rbNzuqDOmgiKwWpx6v0+APkM5HUA0NiIZpgsQ==
+  dependencies:
+    async-disk-cache "^2.0.0"
+    async-promise-queue "^1.0.3"
+    broccoli-plugin "^4.0.3"
+    fs-tree-diff "^2.0.0"
+    hash-for-dep "^1.5.0"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    promise-map-series "^0.2.1"
+    rimraf "^3.0.0"
+    symlink-or-copy "^1.0.1"
+    sync-disk-cache "^2.0.0"
+
+broccoli-persistent-filter@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz#41da6b9577be09a170ecde185f2c5a6099f99c4e"
+  integrity sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==
   dependencies:
     async-disk-cache "^2.0.0"
     async-promise-queue "^1.0.3"
@@ -7176,13 +7193,6 @@ graphql-tools@^4.0.8:
     iterall "^1.1.3"
     uuid "^3.1.0"
 
-graphql@^14.0.2:
-  version "14.7.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.7.0.tgz#7fa79a80a69be4a31c27dda824dc04dac2035a72"
-  integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==
-  dependencies:
-    iterall "^1.2.2"
-
 graphql@^15.3.0:
   version "15.3.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.3.0.tgz#3ad2b0caab0d110e3be4a5a9b2aa281e362b5278"
@@ -7976,7 +7986,7 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-iterall@^1.1.3, iterall@^1.2.2:
+iterall@^1.1.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
@@ -9190,6 +9200,11 @@ object-hash@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
   integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
+
+object-hash@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.0.3.tgz#d12db044e03cd2ca3d77c0570d87225b02e1e6ea"
+  integrity sha512-JPKn0GMu+Fa3zt3Bmr66JhokJU5BaNBIh4ZeTlaCBzrBsOeXzwcKKAK1tbLiPKgvwmPXsDvvLHoWh5Bm7ofIYg==
 
 object-inspect@^1.7.0, object-inspect@^1.8.0:
   version "1.8.0"


### PR DESCRIPTION
This bumps the `broccoli-graphql-filter` dependency to 1.0.0. The [only breaking change](https://github.com/dfreeman/broccoli-graphql-filter/blob/master/CHANGELOG.md) there is explicit support for node 10+ only, which is already the support policy of this addon, so this should not count as breaking change here.