### PR TITLE
Update ember-simple-auth example

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,14 +518,12 @@ The `apollo` service has the following public API:
         return {};
       }
       return new Promise(success => {
-        this.get('session').authorize(
-          'authorizer:oauth2',
-          (headerName, headerContent) => {
-            let headers = {};
-            headers[headerName] = headerContent;
-            success({ headers });
-          }
-        );
+        let headers = {};
+        if (this.get('session.isAuthenticated')) {
+          let token =this.get('session.data.authenticated.token');
+          headers['Authorization'] = `Bearer ${token}`;
+        }
+        success({ headers });
       });
     }
   }

--- a/README.md
+++ b/README.md
@@ -519,10 +519,9 @@ The `apollo` service has the following public API:
       }
       return new Promise(success => {
         let headers = {};
-        if (this.get('session.isAuthenticated')) {
-          let token = this.get('session.data.authenticated.token');
-          headers['Authorization'] = `Bearer ${token}`;
-        }
+        let token = this.get('session.data.authenticated.token');
+        headers['Authorization'] = `Bearer ${token}`;
+
         success({ headers });
       });
     }

--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ The `apollo` service has the following public API:
       return new Promise(success => {
         let headers = {};
         if (this.get('session.isAuthenticated')) {
-          let token =this.get('session.data.authenticated.token');
+          let token = this.get('session.data.authenticated.token');
           headers['Authorization'] = `Bearer ${token}`;
         }
         success({ headers });


### PR DESCRIPTION
ember-simple-auth no longer has an `authorize` method (see e.g. simplabs/ember-simple-auth#2010 )

Update example to reduce confusion.