### PR TITLE
Support in-addon and in-engine options

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,16 +31,20 @@ module.exports = {
   },
 
   getOptions() {
+    const hostOptions =
+      (this.parent && this.parent.options) ||
+      (this.app && this.app.options) ||
+      {};
+
     return (
-      (this.app && this.app.options.emberApolloClient) || {
+      hostOptions.emberApolloClient || {
         keepGraphqlFileExtension: true,
       }
     );
   },
 
   setupPreprocessorRegistry(type, registry) {
-    let getOptions = this.getOptions.bind(this);
-    let options = getOptions();
+    const options = this.getOptions();
 
     if (type === 'parent') {
       registry.add('js', {


### PR DESCRIPTION
Hi!

We're using `ember-apollo-client` as a dependency of an internal engine which also has it's own query and mutation files. It seems the `emberApolloClient` options are only read from the `app` property which is not set in case of an addon/engine.
For an addon/engine these options can be read from the `parent` property instead.

The solution is borrowed from this [ember-composable-helpers LOC](https://github.com/DockYard/ember-composable-helpers/blob/master/index.js#L22).