### PR TITLE
Remove webpack configuration for externalising react

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,6 @@ module.exports = {
             },
           ],
         },
-        externals: {
-          react: 'react',
-        },
       },
     },
   },


### PR DESCRIPTION
Since already we use the `@apollo/client/core` import, `react` won't be
included in the build.

Closes https://github.com/ember-graphql/ember-apollo-client/issues/389