### PR TITLE
Added tracking to the returned result object when assigning data

### DIFF
--- a/tests/acceptance/watch-query-test.js
+++ b/tests/acceptance/watch-query-test.js
@@ -13,6 +13,24 @@ module('Acceptance | watch query', function (hooks) {
     posterPath: '/dM2w364MScsjFf8pfMbaWUcWrR.jpg',
     overview: 'lorem',
     releaseDate: '1994-10-14',
+    reviews: {
+      edges: [],
+      __typename: 'ReviewsConnection',
+    },
+    __typename: 'Movie',
+  };
+
+  const mockReviews = {
+    edges: [
+      {
+        node: {
+          stars: 5,
+          __typename: 'Review',
+        },
+        __typename: 'ReviewEdge',
+      },
+    ],
+    __typename: 'ReviewsConnection',
   };
 
   test('data should be updated when executing a mutation', async function (assert) {
@@ -64,7 +82,10 @@ module('Acceptance | watch query', function (hooks) {
             return new Promise((resolve) => {
               setTimeout(() => {
                 resolve(
-                  Object.assign({}, mockMovie, { title: 'The Godfather' })
+                  Object.assign({}, mockMovie, {
+                    title: 'The Godfather',
+                    reviews: mockReviews,
+                  })
                 );
               }, 200);
             });
@@ -81,11 +102,13 @@ module('Acceptance | watch query', function (hooks) {
     assert.equal(currentURL(), '/movie/680');
 
     assert.dom('.movie-title').hasText('Pulp Fiction');
+    assert.dom('.movie-reviews').hasText('No reviews');
 
     isRefetch = true;
     await click('.refetch-data-using-observable');
 
     assert.dom('.movie-title').hasText('The Godfather');
+    assert.dom('.movie-reviews').hasText('5 stars');
   });
 
   test('refetch using reoute refresh should update template', async function (assert) {

--- a/tests/dummy/app/controllers/movie.js
+++ b/tests/dummy/app/controllers/movie.js
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+
+export default class MovieController extends Controller {
+  get reviews() {
+    return this.model.movie.reviews.edges.map((edge) => {
+      return edge.node;
+    });
+  }
+}

--- a/tests/dummy/app/gql/queries/movie.graphql
+++ b/tests/dummy/app/gql/queries/movie.graphql
@@ -6,5 +6,12 @@ query GetMovie($id: ID!) {
     voteAverage
     posterPath
     releaseDate
+    reviews {
+      edges {
+        node {
+          stars
+        }
+      }
+    }
   }
 }

--- a/tests/dummy/app/instance-initializers/mock-graphql.js
+++ b/tests/dummy/app/instance-initializers/mock-graphql.js
@@ -115,6 +115,10 @@ function startPretender() {
     Date() {
       return '2019-09-28';
     },
+
+    Int() {
+      return 5;
+    },
   };
 
   let schema = makeExecutableSchema({ typeDefs: schemaString, resolvers });

--- a/tests/dummy/app/schema.graphql
+++ b/tests/dummy/app/schema.graphql
@@ -24,6 +24,7 @@ type Movie {
   voteAverage: Float
   posterPath: String
   releaseDate: Date
+  reviews: ReviewsConnection!
 }
 
 # Represents a review for a movie
@@ -33,6 +34,14 @@ type Review {
 
   # Comment about the movie
   commentary: String
+}
+
+type ReviewEdge {
+  node: Review!
+}
+
+type ReviewsConnection {
+  edges: [ReviewEdge]!
 }
 
 # The input object sent when someone is creating a new review

--- a/tests/dummy/app/templates/movie.hbs
+++ b/tests/dummy/app/templates/movie.hbs
@@ -38,3 +38,11 @@
 </div>
 
 <MovieDetail @movie={{this.model.movie}} />
+
+<div class="movie-reviews">
+  {{#each this.reviews as |review|}}
+    <p>{{review.stars}} stars</p>
+  {{else}}
+    <p>No reviews</p>
+  {{/each}}
+</div>


### PR DESCRIPTION
Attempt number 2 at resolving an issue where cache updates would be visible to the Ember observation system but _not_ Glimmer's autotracking system. From the description of my first attempt (#398):

> I was running into an issue (possibly related to #384) where native getters on my controllers would not recompute their values when the Apollo cache was updated. This became especially apparent when using an API that took advantage of relay-style pagination: a computed property that pulled out all the edges' nodes on a field would not update when either the node was changed or a new edge was added (e.g., as part of a create mutation). What I found particularly odd was that I could make the update work if I added a `@computed` decorator to the getter. So, for example:

```javascript
// This did not update when the underlying cache updated
get reviews() { return this.model.movie.reviews.edges.map(edge => edge.node); }

// ... but this did!
@computed('model.movie.reviews.edges.@each.node')
get reviews() { return this.model.movie.reviews.edges.map(edge => edge.node); }
```

> Because I could get it to work using the decorator, it seemed like there was something that wasn't getting set up for autotracking using `@tracked` when the data was initially assigned, resulting in `setProperties()` doing nothing until something registered that it was watching the value via the classic observation system.

I first tried simply adding [`tracked-built-ins`](https://github.com/pzuraq/tracked-built-ins), but it uses `Proxy` under-the-hood, which rules out support for IE11 (since IE does not and never will support Proxy). 😞 Understandably, that was a show-stopper for taking that route. 

This second attempt uses a similar (but IE-compatible) approach, creating a class for the sake of facilitating tracking changes to an object's properties in the autotracking system. Since values are assigned to our storage `obj` using Ember's `setProperties`, we can take advantage of the fact that Ember's `set` first looks for a `setUnknownProperty` method and then use that to JIT define a `@tracked` property on our `obj` before assignment. To preserve POJO behavior, the `setUnknownProperty` method is not enumerable, while all JIT-defined properties are. The end result is that reads and writes to those JIT-defined properties are properly tracked in the autotracking system so that cache updates are reflected as expected in the DOM. 😁 

Thanks (again!) for your consideration. 🙂 