### PR TITLE
[CHORE] Move dependencies to dependencies block

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@apollo/client": "^3.2.1",
     "@ember/test-waiters": "^2.3.0",
+    "@glimmer/tracking": "^1.0.2",
     "broccoli-graphql-filter": "^1.0.0",
     "ember-auto-import": "^1.6.0",
     "ember-cli-babel": "^7.22.1"
@@ -44,7 +45,6 @@
     "@babel/core": "^7.11.6",
     "@ember/optional-features": "^2.0.0",
     "@glimmer/component": "^1.0.2",
-    "@glimmer/tracking": "^1.0.2",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~3.21.2",


### PR DESCRIPTION
Move glimmer dependencies to the dependencies block in the `package.json`

Fixes #406 