### PR TITLE
breaking: Drop node 18 support, min node v20.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --no-lockfile
@@ -81,7 +81,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "engines": {
-    "node": ">= 18"
+    "node": ">= 20"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Ember CLI requires node 20, so no reason to allow node 18. With node 18, we do have issues with floating deps failing.